### PR TITLE
Fix curl -sf causing CI step failure under bash -e

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Get latest crates.io version
         id: upstream
         run: |
-          response=$(curl -sf 'https://crates.io/api/v1/crates/${{ matrix.crate }}')
+          response=$(curl -sf 'https://crates.io/api/v1/crates/${{ matrix.crate }}') || true
           version=$(echo "$response" | jq -r '.crate.max_stable_version // empty')
           if [ -z "$version" ]; then
             echo "::warning::Could not determine latest stable version for ${{ matrix.crate }}"


### PR DESCRIPTION
## Summary
- Fix `curl -sf` aborting the "Get latest crates.io version" step with exit code 22 when the API returns an HTTP error
- GitHub Actions runs `bash -e`, so the non-zero exit from curl kills the step before reaching the graceful fallback logic
- Adding `|| true` lets execution continue to the version validation check

## Test plan
- [ ] Trigger the `check-upstream` workflow via `workflow_dispatch` and verify all three matrix jobs complete without failure

Fixes #10

https://claude.ai/code/session_01QLYsoqoSpk2DMTRkc85k2N