### PR TITLE
Add User-Agent header to crates.io API request

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Get latest crates.io version
         id: upstream
         run: |
-          response=$(curl -sf 'https://crates.io/api/v1/crates/${{ matrix.crate }}') || true
+          response=$(curl -sf -H 'User-Agent: timely-skill CI (github.com/antiguru/timely-skill)' \
+            'https://crates.io/api/v1/crates/${{ matrix.crate }}') || true
           version=$(echo "$response" | jq -r '.crate.max_stable_version // empty')
           if [ -z "$version" ]; then
             echo "::warning::Could not determine latest stable version for ${{ matrix.crate }}"


### PR DESCRIPTION
## Summary
- Add required `User-Agent` header to the crates.io API curl request
- crates.io returns 403 without a User-Agent per their [data access policy](https://crates.io/data-access), causing version extraction to always fail
- Also includes the previous fix for `curl -sf` aborting the step under `bash -e`

## Test plan
- [ ] Trigger the `check-upstream` workflow via `workflow_dispatch` and verify all three matrix jobs successfully extract the upstream version

Fixes #10

https://claude.ai/code/session_01QLYsoqoSpk2DMTRkc85k2N