### PR TITLE
Add automated version bumping and release workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,71 @@
+name: Bump version and release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get current version
+        id: current
+        run: |
+          version=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version
+        id: next
+        run: |
+          IFS='.' read -r major minor patch <<< "${{ steps.current.outputs.version }}"
+          case "${{ inputs.bump }}" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          version="${major}.${minor}.${patch}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Bumping ${{ steps.current.outputs.version }} → $version"
+
+      - name: Update version in all plugin files
+        env:
+          OLD_VERSION: ${{ steps.current.outputs.version }}
+          NEW_VERSION: ${{ steps.next.outputs.version }}
+        run: |
+          files=(
+            .claude-plugin/marketplace.json
+            skills/writing-timely-operators/.claude-plugin/plugin.json
+            skills/writing-differential-operators/.claude-plugin/plugin.json
+            skills/using-columnar/.claude-plugin/plugin.json
+          )
+          for f in "${files[@]}"; do
+            jq --arg v "$NEW_VERSION" '
+              if .plugins then .plugins[].version = $v
+              else .version = $v
+              end
+            ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+          done
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Release v${{ steps.next.outputs.version }}"
+          git tag "v${{ steps.next.outputs.version }}"
+          git push origin HEAD "v${{ steps.next.outputs.version }}"


### PR DESCRIPTION
## Summary
This PR introduces a new GitHub Actions workflow that automates the version bumping and release process for the project.

## Key Changes
- Added `.github/workflows/bump-version.yml` workflow that:
  - Accepts manual trigger via `workflow_dispatch` with a choice input for bump type (major, minor, patch)
  - Reads the current version from `.claude-plugin/marketplace.json`
  - Computes the next version based on the selected bump type using semantic versioning
  - Updates version strings across all plugin configuration files:
    - `.claude-plugin/marketplace.json`
    - `skills/writing-timely-operators/.claude-plugin/plugin.json`
    - `skills/writing-differential-operators/.claude-plugin/plugin.json`
    - `skills/using-columnar/.claude-plugin/plugin.json`
  - Creates a commit with the version bump and tags it with the new version
  - Pushes both the commit and tag to the repository

## Implementation Details
- Uses `jq` for JSON parsing and updating version fields across multiple file formats
- Configures git with the GitHub Actions bot identity for commits
- Requires `contents: write` permission to push commits and tags
- Fetches full git history (`fetch-depth: 0`) to ensure proper tag operations

https://claude.ai/code/session_01E2HEykUgvcqiEJoSVmg3Gn