### PR TITLE
Automate release workflow for branch-protected repos

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,4 +1,4 @@
-name: Bump version and release
+name: Bump version
 
 on:
   workflow_dispatch:
@@ -14,14 +14,13 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Get current version
         id: current
@@ -44,7 +43,6 @@ jobs:
 
       - name: Update version in all plugin files
         env:
-          OLD_VERSION: ${{ steps.current.outputs.version }}
           NEW_VERSION: ${{ steps.next.outputs.version }}
         run: |
           files=(
@@ -61,11 +59,19 @@ jobs:
             ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
           done
 
-      - name: Commit and tag
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.next.outputs.version }}
         run: |
+          branch="release/v${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
           git add -A
-          git commit -m "Release v${{ steps.next.outputs.version }}"
-          git tag "v${{ steps.next.outputs.version }}"
-          git push origin HEAD "v${{ steps.next.outputs.version }}"
+          git commit -m "Release v${VERSION}"
+          git push -u origin "$branch"
+          gh pr create \
+            --title "Release v${VERSION}" \
+            --body "Bump version to ${VERSION} (${{ inputs.bump }})." \
+            --label "release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,35 @@
 name: Release plugin
 
 on:
-  push:
-    tags:
-      - 'v*'
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
 
 jobs:
   release:
+    if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Get version from plugin files
+        id: version
+        run: |
+          version=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Package plugin
         run: |
@@ -24,5 +41,6 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ steps.version.outputs.version }}
           files: dist/*.skill
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- **bump-version.yml**: Manual `workflow_dispatch` that bumps semver (patch/minor/major) across all `plugin.json` and `marketplace.json` files, then opens a PR from a `release/vX.Y.Z` branch
- **release.yml**: Triggers when a `release/v*` PR merges to main — creates the git tag, packages the `.skill` zip, and creates a GitHub release
- No more manual tag pushing; branch protection rules are respected throughout

## Test plan
- [ ] Run "Bump version" workflow with `patch` and verify a PR is created with updated versions
- [ ] Merge the release PR and verify a tag, GitHub release, and `.skill` artifact are created

https://claude.ai/code/session_01E2HEykUgvcqiEJoSVmg3Gn