### PR TITLE
Update skills for timely 0.29 and differential-dataflow 0.23

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 This repo contains Claude Code skills for writing timely dataflow and differential dataflow operators.
 
+## Writing style
+
+* Use a concise, technical writing style.
+* Avoid filler words, use active voice.
+* Only make claims based on evidence.
+  If there's no evidence, ask what to do.
+
+## Markdown formatting
+
+* Use the asterisk `*` for lists, not dash `-`.
+* Put each sentence on its own line.
+* Capitalization of headers: first word upper case, and after colon.
+  Uppercase proper nouns, but no other words.
+* When changing code, do not drop comments.
+
 ## Skill content style
 
 * Skills are API references for the current version. Not migration guides.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Timely skill
+
+This repo contains Claude Code skills for writing timely dataflow and differential dataflow operators.
+
+## Skill content style
+
+* Skills are API references for the current version. Not migration guides.
+* State what IS, not what WAS.
+  No "was removed", "no longer", "earlier versions", "replaced by".
+* Version references only in the target version line at the top of each skill (e.g., "This skill targets **timely v0.29**.").
+  Do not reference version numbers elsewhere in the skill body.
+
+## Updating skills for new releases
+
+* Check crates.io for latest versions of timely, differential-dataflow, and columnar.
+* Fetch changelogs or release notes to identify actual API changes.
+  Do not blindly bump version numbers — verify what changed.
+* Update type signatures, code examples, and descriptive text to match the new API.
+* After editing, scan each skill for stale references (old type names, removed traits, outdated generic bounds).

--- a/skills/using-columnar/SKILL.md
+++ b/skills/using-columnar/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 # Using the columnar crate
 
-This skill targets **columnar v0.12**.
+This skill targets **columnar v0.12.1**.
 API details may differ in other versions — check `frankmcsherry/columnar` source when in doubt.
 
 Columnar transforms arrays of complex structs into structs of simple arrays (AoS → SoA).

--- a/skills/writing-differential-operators/SKILL.md
+++ b/skills/writing-differential-operators/SKILL.md
@@ -12,7 +12,7 @@ description: >
 
 # Writing differential dataflow operators
 
-This skill targets **differential-dataflow v0.21** (depends on timely v0.28 and columnar v0.12).
+This skill targets **differential-dataflow v0.23** (depends on timely v0.29 and columnar v0.12).
 API details may differ in other versions — check source files when in doubt.
 
 Differential dataflow builds on timely dataflow.
@@ -22,21 +22,21 @@ For timely-level operator construction (capabilities, frontiers, draining), see 
 ## The Collection type
 
 ```rust
-pub struct Collection<G: Scope, C: 'static> {
-    pub inner: Stream<G, C>,
+pub struct Collection<'scope, T: Timestamp, C: 'static> {
+    pub inner: Stream<'scope, T, C>,
 }
 ```
 
 A `Collection` wraps a timely `Stream`.
-The container type `C` is typically `Vec<(D, G::Timestamp, R)>` where `D` is the data, and `R` is the difference type (usually `isize`).
-The shorthand `VecCollection<G, D, R>` refers to `Collection<G, Vec<(D, G::Timestamp, R)>>`.
+The container type `C` is typically `Vec<(D, T, R)>` where `D` is the data, and `R` is the difference type (usually `isize`).
+The shorthand `VecCollection<'scope, T, D, R>` refers to `Collection<'scope, T, Vec<(D, T, R)>>`.
 
 `+1` means an insertion, `-1` a retraction.
 An update `(d, t, +1)` followed by `(d, t, -1)` cancels out — `d` was never logically present at time `t`.
 
 ## High-level operators
 
-In v0.21, high-level operators (`join`, `reduce`, `arrange_by_key`, etc.) are methods directly on `Collection` — the separate `Join`, `JoinCore`, `Reduce`, `ArrangeByKey`, `ArrangeBySelf` extension traits from earlier versions are removed.
+High-level operators (`join`, `reduce`, `arrange_by_key`, etc.) are methods directly on `Collection` — the separate `Join`, `JoinCore`, `Reduce`, `ArrangeByKey`, `ArrangeBySelf` extension traits from earlier versions are removed.
 
 All operators below are methods on `Collection`.
 
@@ -62,7 +62,7 @@ Do not over-consolidate — each call is an exchange + sort.
 
 ### Keyed operators
 
-These operate on `Collection<G, Vec<((K, V), T, R)>>` — collections of key-value pairs.
+These operate on `Collection<'scope, T, Vec<((K, V), T, R)>>` — collections of key-value pairs.
 
 **`reduce`**: Per-key aggregation.
 ```rust
@@ -79,8 +79,8 @@ It must be deterministic — DD calls it repeatedly to compute retractions when 
 
 **`join`** / **`join_map`**: Equijoin on key.
 ```rust
-left.join(&right)  // -> Collection<G, (K, (V1, V2)), R>
-left.join_map(&right, |key, v1, v2| result)  // -> Collection<G, D, R>
+left.join(&right)  // -> VecCollection<'scope, T, (K, (V1, V2)), R>
+left.join_map(&right, |key, v1, v2| result)  // -> VecCollection<'scope, T, D, R>
 ```
 
 Internally, `join` arranges both inputs by key, then calls `join_core`.
@@ -111,12 +111,11 @@ An arrangement is a persistent, indexed representation of a collection.
 Multiple operators can share the same arrangement, avoiding redundant storage and computation.
 
 ```rust
-pub struct Arranged<G, Tr>
+pub struct Arranged<'scope, Tr>
 where
-    G: Scope<Timestamp: Lattice + Ord>,
     Tr: TraceReader + Clone,
 {
-    pub stream: Stream<G, Vec<Tr::Batch>>,
+    pub stream: Stream<'scope, Tr::Time, Vec<Tr::Batch>>,
     pub trace: Tr,
 }
 ```
@@ -191,21 +190,27 @@ Use these when you already have an arrangement to avoid redundant re-arrangement
 ### `reduce_trace`
 
 ```rust
-pub fn reduce_trace<G, T1, Bu, T2, L>(
-    trace: Arranged<G, T1>,
+pub fn reduce_trace<'scope, Tr1, Bu, Tr2, L, P>(
+    trace: Arranged<'scope, Tr1>,
     name: &str,
     logic: L,
-) -> Arranged<G, TraceAgent<T2>>
+    push: P,
+) -> Arranged<'scope, TraceAgent<Tr2>>
 ```
 
 The logic closure signature:
 ```rust
 FnMut(
-    T1::Key<'_>,                       // key
-    &[(T1::Val<'_>, T1::Diff)],        // consolidated input values + diffs
-    &mut Vec<(T2::ValOwn, T2::Diff)>,  // output buffer
-    &mut Vec<(T2::ValOwn, T2::Diff)>,  // update buffer (for retractions)
+    Tr1::Key<'_>,                       // key
+    &[(Tr1::Val<'_>, Tr1::Diff)],       // consolidated input values + diffs
+    &mut Vec<(Tr2::ValOwn, Tr2::Diff)>, // output buffer
+    &mut Vec<(Tr2::ValOwn, Tr2::Diff)>, // update buffer (for retractions)
 )
+```
+
+The `push` closure packs key + value updates into the builder input, decoupling the packing strategy from the reduce implementation:
+```rust
+P: FnMut(&mut Bu::Input, Tr1::Key<'_>, &mut Vec<(Tr2::ValOwn, Tr2::Time, Tr2::Diff)>)
 ```
 
 Returns an `Arranged` — the output is itself an arrangement, usable as input to further core operators.
@@ -221,11 +226,11 @@ For maximum control, `join_core_internal_unsafe` gives the closure direct cursor
 ### `arrange_core`
 
 ```rust
-pub fn arrange_core<G, P, Ba, Bu, Tr>(
-    stream: Stream<G, Ba::Input>,
+pub fn arrange_core<'scope, P, Ba, Bu, Tr>(
+    stream: Stream<'scope, Tr::Time, Ba::Input>,
     pact: P,
     name: &str,
-) -> Arranged<G, TraceAgent<Tr>>
+) -> Arranged<'scope, TraceAgent<Tr>>
 ```
 
 Parameterized by batcher (`Ba`), builder (`Bu`), and trace (`Tr`) types.
@@ -288,7 +293,7 @@ let result = collection.iterate(|scope, inner| {
     // Fixed point when no new updates are produced.
     inner
         .map(|x| step(x))
-        .concat(&input.enter(&scope))
+        .concat(&input.enter(scope))
         .distinct()
 });
 ```
@@ -300,8 +305,9 @@ Multiple variables enable mutual recursion.
 
 Inside the iterative scope, the feedback edge has summary `Product::new(Default::default(), 1)` — each iteration increments the inner timestamp by 1.
 
-**`enter` / `leave`**: `enter` wraps each timestamp in `Product<T, u64>` with inner = 0.
-`leave` strips the inner coordinate.
+**`enter` / `leave`**: `enter(scope)` wraps each timestamp in `Product<T, u64>` with inner = 0.
+`leave(outer_scope)` strips the inner coordinate.
+Both take the target scope by value (`Scope` is `Copy`).
 
 ## Difference algebra
 
@@ -331,13 +337,13 @@ The `dogsdogsdogs` crate (published as `differential-dogs3`) provides multi-way 
 ### half_join
 
 ```rust
-pub fn half_join<G, K, V, R, Tr, FF, CF, DOut, S>(
-    stream: VecCollection<G, (K, V, G::Timestamp), R>,
-    arrangement: Arranged<G, Tr>,
+pub fn half_join<'scope, K, V, R, Tr, FF, CF, DOut, S>(
+    stream: VecCollection<'scope, Tr::Time, (K, V, Tr::Time), R>,
+    arrangement: Arranged<'scope, Tr>,
     frontier_func: FF,
     comparison: CF,
     output_func: S,
-) -> VecCollection<G, (DOut, G::Timestamp), <R as Mul<Tr::Diff>>::Output>
+) -> VecCollection<'scope, Tr::Time, (DOut, Tr::Time), <R as Mul<Tr::Diff>>::Output>
 ```
 
 A half join matches updates from one stream against an arrangement where the arranged data's timestamp satisfies a comparison function under a total order on time.

--- a/skills/writing-differential-operators/SKILL.md
+++ b/skills/writing-differential-operators/SKILL.md
@@ -36,7 +36,7 @@ An update `(d, t, +1)` followed by `(d, t, -1)` cancels out — `d` was never lo
 
 ## High-level operators
 
-High-level operators (`join`, `reduce`, `arrange_by_key`, etc.) are methods directly on `Collection` — the separate `Join`, `JoinCore`, `Reduce`, `ArrangeByKey`, `ArrangeBySelf` extension traits from earlier versions are removed.
+High-level operators (`join`, `reduce`, `arrange_by_key`, etc.) are methods directly on `Collection`.
 
 All operators below are methods on `Collection`.
 

--- a/skills/writing-timely-operators/SKILL.md
+++ b/skills/writing-timely-operators/SKILL.md
@@ -10,11 +10,27 @@ description: >
 
 # Writing timely dataflow operators
 
-This skill targets **timely v0.28**.
+This skill targets **timely v0.29**.
 API details (especially closure signatures and container traits) may differ in other versions — check source files when in doubt.
 
 This skill covers the patterns for writing correct and efficient custom operators in timely dataflow.
 When writing an operator, read the relevant section below, then check the source files it references for the current API signatures.
+
+## Scope type
+
+In v0.29, `Scope<'scope, T>` is a concrete `Copy` struct, not a trait.
+Code that was generic over `G: Scope` in earlier versions now uses `Scope<'scope, T>` with an explicit lifetime and timestamp parameter.
+`Child<'scope, G, T>` is removed — use `Scope<'scope, T>` directly.
+
+Dataflow closures receive the scope by value:
+
+```rust
+worker.dataflow(|scope: Scope<'_, usize>| {
+    // scope is Copy — pass it freely
+});
+```
+
+Access the worker via `scope.worker()` — the `AsWorker` and `Scheduler` traits are removed; their methods are now inherent on `Worker`.
 
 ## All workers must construct the same dataflow graph
 
@@ -70,7 +86,7 @@ For the frontier variants, the logic closure receives input handles paired with 
 For `OperatorBuilder` (in `builder_rc.rs`), you wire inputs and outputs manually:
 
 ```
-let mut builder = OperatorBuilder::new("Name".to_owned(), scope.clone());
+let mut builder = OperatorBuilder::new("Name".to_owned(), scope);
 let mut input = builder.new_input(&stream, Pipeline);
 let (mut output_wrapper, output_stream) = builder.new_output();
 
@@ -258,6 +274,8 @@ This works well for operators that can process all input promptly.
 But if an operator produces far more output than it receives (e.g., `flat_map(|x| 0..x)` on large values), running to completion can flood memory.
 
 **Yielding with `build_reschedule`** (on `OperatorBuilder`): The logic closure returns `bool` — `true` means "schedule me again even without new input."
+In v0.29, `build_reschedule` boxes the closures by default, reducing compile times.
+Use `build_reschedule_typed` for the monomorphized (non-boxed) path when needed.
 This lets you process input incrementally:
 
 ```
@@ -360,19 +378,20 @@ This is a type annotation, not a runtime conversion — it tells the type system
 All built-in timely operators (`filter`, `map`, `inspect`, `exchange`, etc.) are defined as extension traits on `Stream`.
 Follow this pattern to make custom operators feel like first-class methods.
 
-Define a trait parameterized by the scope and constrain it to `Stream`:
+Define a trait parameterized by the scope lifetime and timestamp, and implement it for `Stream`:
 
 ```
 use timely::dataflow::{Scope, Stream};
 use timely::dataflow::operators::generic::operator::Operator;
 use timely::dataflow::channels::pact::Pipeline;
+use timely::progress::Timestamp;
 
 /// Doubles every record in the stream.
-pub trait DoubleStream<G: Scope, D: Clone + 'static> {
+pub trait DoubleStream<'scope, T: Timestamp, D: Clone + 'static> {
     fn double(self) -> Self;
 }
 
-impl<G: Scope, D: Clone + 'static> DoubleStream<G, D> for Stream<G, Vec<D>> {
+impl<'scope, T: Timestamp, D: Clone + 'static> DoubleStream<'scope, T, D> for Stream<'scope, T, Vec<D>> {
     fn double(self) -> Self {
         self.unary(Pipeline, "Double", |_, _| {
             move |input, output| {
@@ -394,17 +413,17 @@ impl<G: Scope, D: Clone + 'static> DoubleStream<G, D> for Stream<G, Vec<D>> {
 This pattern has a few advantages:
 * Callers chain it naturally: `stream.double().inspect(...)`.
 * The trait can be imported selectively, avoiding name collisions.
-* Scope and timestamp constraints go on the trait or impl, not on every call site.
+* Lifetime and timestamp constraints go on the trait or impl, not on every call site.
 
 For operators that need `OperatorBuilder` (multiple outputs, yielding), the extension trait returns the output stream(s) and hides the builder wiring:
 
 ```
-pub trait ExpandRange<G: Scope> {
-    fn expand_range(self) -> Stream<G, Vec<u64>>;
+pub trait ExpandRange<'scope> {
+    fn expand_range(self) -> Stream<'scope, u64, Vec<u64>>;
 }
 
-impl<G: Scope<Timestamp = u64>> ExpandRange<G> for Stream<G, Vec<u64>> {
-    fn expand_range(self) -> Stream<G, Vec<u64>> {
+impl<'scope> ExpandRange<'scope> for Stream<'scope, u64, Vec<u64>> {
+    fn expand_range(self) -> Stream<'scope, u64, Vec<u64>> {
         let mut builder = OperatorBuilder::new("ExpandRange".to_owned(), self.scope());
         let mut input = builder.new_input(self, Pipeline);
         let (output, stream) = builder.new_output::<Vec<u64>>();
@@ -417,7 +436,7 @@ impl<G: Scope<Timestamp = u64>> ExpandRange<G> for Stream<G, Vec<u64>> {
 For operators that split a stream, return a tuple:
 
 ```
-pub trait SplitOddEven<G: Scope> {
-    fn split_odd_even(self) -> (Stream<G, Vec<u64>>, Stream<G, Vec<u64>>);
+pub trait SplitOddEven<'scope> {
+    fn split_odd_even(self) -> (Stream<'scope, u64, Vec<u64>>, Stream<'scope, u64, Vec<u64>>);
 }
 ```

--- a/skills/writing-timely-operators/SKILL.md
+++ b/skills/writing-timely-operators/SKILL.md
@@ -18,9 +18,7 @@ When writing an operator, read the relevant section below, then check the source
 
 ## Scope type
 
-In v0.29, `Scope<'scope, T>` is a concrete `Copy` struct, not a trait.
-Code that was generic over `G: Scope` in earlier versions now uses `Scope<'scope, T>` with an explicit lifetime and timestamp parameter.
-`Child<'scope, G, T>` is removed — use `Scope<'scope, T>` directly.
+`Scope<'scope, T>` is a concrete `Copy` struct with an explicit lifetime and timestamp parameter.
 
 Dataflow closures receive the scope by value:
 
@@ -30,7 +28,7 @@ worker.dataflow(|scope: Scope<'_, usize>| {
 });
 ```
 
-Access the worker via `scope.worker()` — the `AsWorker` and `Scheduler` traits are removed; their methods are now inherent on `Worker`.
+Access the worker via `scope.worker()`. Worker methods like `logging()` and `config()` are inherent on `Worker`.
 
 ## All workers must construct the same dataflow graph
 

--- a/skills/writing-timely-operators/SKILL.md
+++ b/skills/writing-timely-operators/SKILL.md
@@ -272,8 +272,8 @@ This works well for operators that can process all input promptly.
 But if an operator produces far more output than it receives (e.g., `flat_map(|x| 0..x)` on large values), running to completion can flood memory.
 
 **Yielding with `build_reschedule`** (on `OperatorBuilder`): The logic closure returns `bool` — `true` means "schedule me again even without new input."
-In v0.29, `build_reschedule` boxes the closures by default, reducing compile times.
-Use `build_reschedule_typed` for the monomorphized (non-boxed) path when needed.
+`build_reschedule` boxes the closures by default, reducing compile times.
+`build_reschedule_typed` provides the monomorphized (non-boxed) path when needed.
 This lets you process input incrementally:
 
 ```


### PR DESCRIPTION
* Update writing-timely-operators skill from timely v0.28 to v0.29
* Update writing-differential-operators skill from differential-dataflow v0.21 to v0.23
* Update using-columnar skill to v0.12.1 (bug fix only)

Key API changes covered:
* `Scope` is now a concrete `Copy` struct, not a trait (`G: Scope` → `Scope<'scope, T>`)
* `Collection<G, C>` → `Collection<'scope, T, C>`, `Arranged<G, Tr>` → `Arranged<'scope, Tr>`
* `reduce_trace` gains a `push` closure parameter
* `enter`/`leave` take scope by value; `leave` requires outer scope argument
* `build_reschedule` boxes closures by default; `build_reschedule_typed` for monomorphized path
* `AsWorker`/`Scheduler` traits removed; methods now inherent on `Worker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)