### PR TITLE
Update skills for timely 0.30, differential 0.24, columnar 0.13

### DIFF
--- a/skills/using-columnar/SKILL.md
+++ b/skills/using-columnar/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 # Using the columnar crate
 
-This skill targets **columnar v0.12.1**.
+This skill targets **columnar v0.13.0**.
 API details may differ in other versions — check `frankmcsherry/columnar` source when in doubt.
 
 Columnar transforms arrays of complex structs into structs of simple arrays (AoS → SoA).
@@ -236,14 +236,21 @@ Containers implement `AsBytes` and `FromBytes` for zero-copy-friendly serializat
 
 ```rust
 pub trait AsBytes<'a> {
-    fn as_bytes(&self) -> impl Iterator<Item = (u64, &'a [u8])>;
+    const SLICE_COUNT: usize;
+    fn get_byte_slice(&self, index: usize) -> (u64, &'a [u8]);
+    fn as_bytes(&self) -> impl Iterator<Item = (u64, &'a [u8])> {
+        (0..Self::SLICE_COUNT).map(|i| self.get_byte_slice(i))
+    }
 }
 
 pub trait FromBytes<'a> {
+    const SLICE_COUNT: usize;
     fn from_bytes(bytes: &mut impl Iterator<Item = &'a [u8]>) -> Self;
 }
 ```
 
+`AsBytes` is random-access: implementors provide `SLICE_COUNT` and `get_byte_slice(index)`, and `as_bytes` iterates the slices by default.
+Because `SLICE_COUNT` is a compile-time constant, the encoder indexes slices by position and LLVM constant-folds the dispatch.
 Each `(u64, &[u8])` pair is an alignment hint and a byte slice.
 The wire format (`Indexed`) stores:
 1. An offset table (u64 per slice) for O(1) random access.
@@ -253,7 +260,7 @@ Primitive columns serialize as direct byte casts (`bytemuck`).
 Composite containers (tuples, vecs, strings) recursively serialize each sub-container.
 
 **`DecodedStore`**: A zero-allocation random-access view into indexed-encoded data.
-It provides constant-time field access regardless of tuple width, replacing the legacy `from_u64s` / `decode_u64s` decoding methods.
+It provides constant-time field access regardless of tuple width.
 Derived types support a `from_store` constructor for structured decoding.
 
 **`Stash`**: A container that accumulates byte-serialized data for deferred decoding.
@@ -458,7 +465,7 @@ With columnar storage, a custom `KeyPact` + `KeyDistributor` routes by key witho
 
 ```rust
 let pact = KeyPact { hashfunc: |k: columnar::Ref<'_, Vec<u8>>| k.hashed() };
-let arranged = arrange_core::<_, _, KeyBatcher<_,_,_>, KeyBuilder<_,_,_>, KeySpine<_,_,_>>(
+let arranged = arrange_core::<_, _, _, KeyBatcher<_,_,_>, KeyBuilder<_,_,_>, KeySpine<_,_,_>>(
     stream, pact, "Data"
 );
 ```

--- a/skills/writing-differential-operators/SKILL.md
+++ b/skills/writing-differential-operators/SKILL.md
@@ -12,7 +12,7 @@ description: >
 
 # Writing differential dataflow operators
 
-This skill targets **differential-dataflow v0.23** (depends on timely v0.29 and columnar v0.12).
+This skill targets **differential-dataflow v0.24** and **differential-dogs3 v0.24** (depends on timely v0.30 and columnar v0.13).
 API details may differ in other versions — check source files when in doubt.
 
 Differential dataflow builds on timely dataflow.
@@ -139,7 +139,7 @@ let arranged = collection.arrange_by_self();
 
 Under the hood, `arrange_core` builds a timely operator that:
 1. Receives `(data, time, diff)` triples.
-2. Batches them using a `Batcher` until the frontier advances.
+2. Chunks the input container with a `ContainerBuilder`, then accumulates the chunks in a `Batcher` until the frontier advances.
 3. Seals completed batches and inserts them into the trace.
 4. Outputs batches on the stream for downstream operators.
 
@@ -226,14 +226,15 @@ For maximum control, `join_core_internal_unsafe` gives the closure direct cursor
 ### `arrange_core`
 
 ```rust
-pub fn arrange_core<'scope, P, Ba, Bu, Tr>(
-    stream: Stream<'scope, Tr::Time, Ba::Input>,
+pub fn arrange_core<'scope, P, C, Chu, Ba, Bu, Tr>(
+    stream: Stream<'scope, Tr::Time, C>,
     pact: P,
     name: &str,
 ) -> Arranged<'scope, TraceAgent<Tr>>
 ```
 
-Parameterized by batcher (`Ba`), builder (`Bu`), and trace (`Tr`) types.
+Parameterized by input container (`C`), chunker (`Chu: ContainerBuilder`), batcher (`Ba`), builder (`Bu`), and trace (`Tr`) types.
+The chunker turns the input container into the batcher's input, so the `Batcher` is independent of the input container type.
 The high-level `arrange_by_key` picks sensible defaults.
 
 ## Trace and cursor API
@@ -364,7 +365,7 @@ Key types:
 
 ## Columnar data representation
 
-DD can use columnar containers (from the `columnar` crate v0.12) as backing storage for trace batches.
+DD can use columnar containers (from the `columnar` crate) as backing storage for trace batches.
 The `ColumnarLayout` type maps each column (keys, vals, times, diffs) to columnar storage, and `Coltainer<C>` wraps a columnar container to implement DD's `BatchContainer` trait.
 
 For the full columnar API (traits, derive macro, container types, serialization), see the `using-columnar` skill.

--- a/skills/writing-timely-operators/SKILL.md
+++ b/skills/writing-timely-operators/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 # Writing timely dataflow operators
 
-This skill targets **timely v0.29**.
+This skill targets **timely v0.30**.
 API details (especially closure signatures and container traits) may differ in other versions — check source files when in doubt.
 
 This skill covers the patterns for writing correct and efficient custom operators in timely dataflow.
@@ -149,7 +149,7 @@ input.for_each_time(|time, data| {
 **`for_each`**: Calls your closure once per (capability, container) pair, without grouping.
 Use only when you do not need to create output sessions (e.g., stashing into a buffer).
 
-**`next()`** (private in v0.28): No longer available as public API.
+**`next()`**: Private, not public API.
 Use `for_each` or `for_each_time` instead.
 
 After draining, if the operator needs to defer work (because the frontier has not advanced far enough), stash the data in operator-local state keyed by timestamp.


### PR DESCRIPTION
Verified API changes against tagged source:

* `arrange_core` gains input-container and chunker generics; `Ba::Input` removed.
* `AsBytes` is random-access (`SLICE_COUNT` + `get_byte_slice`); `FromBytes` gains `SLICE_COUNT`.
* Differential target line covers differential-dogs3 v0.24; dogs3 types verified present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)